### PR TITLE
:bug:  多服务配置模式，path去除service.name

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -72,7 +72,9 @@ export function generateControllers(
         .filter(([key]) => key.startsWith('/api') || key.startsWith(`/${service.name}`))
         .forEach(([key, config]: [string, { [keys: string]: any }]) => {
             // 接口路径
-            const path = key
+            const matchServieName = `/${service.name}`
+            // 多服务去除service.name
+            const path =  key.startsWith(matchServieName) ? key.substr(matchServieName.length) : key
             // 接口行为
             Object.entries(config).forEach(
                 ([


### PR DESCRIPTION
多服务模式下，如果生成的path带有service.name 那么在http-request里面，会再和service合成请求url，因此生成的时候去除service.name